### PR TITLE
Adopt Don't Show US 3 complete: Shelter Show Page

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -2,4 +2,8 @@ class SheltersController < ApplicationController
   def index
     @shelters = Shelter.all
   end
+
+  def show
+    @shelter = Shelter.find(params[:id])
+  end
 end

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -1,0 +1,5 @@
+<h1><%= @shelter.name %></h1>
+<p>Address: <%= @shelter.address %></p>
+<p>City: <%= @shelter.city %></p>
+<p>State: <%= @shelter.state %></p>
+<p>Zip: <%= @shelter.zip %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   get '/shelters', to: 'shelters#index'
+  get '/shelters/:id', to: 'shelters#show'
 end

--- a/spec/features/shelters/shelter_show_spec.rb
+++ b/spec/features/shelters/shelter_show_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Shelter Show Page" do
+  describe "as a visitor when I visit a shelter's show page" do
+    it "I can see that shelter's name and location information" do
+      shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+      shelter_2 = Shelter.create(name: "Foothils Animal Shelter", address: "580 McIntyre St", city: "Golden", state: "CO", zip: "80401")
+
+      visit "/shelters/#{shelter_1.id}"
+
+      expect(page).to have_content(shelter_1.name)
+      expect(page).to have_content(shelter_1.address)
+      expect(page).to have_content(shelter_1.city)
+      expect(page).to have_content(shelter_1.state)
+      expect(page).to have_content(shelter_1.zip)
+      expect(page).to_not have_content(shelter_2.name)
+    end
+  end
+end
+
+
+
+# User Story 3, Shelter Show
+#
+# As a visitor
+# When I visit '/shelters/:id'
+# Then I see the shelter with that id including the shelter's:
+# - name
+# - address
+# - city
+# - state
+# - zip


### PR DESCRIPTION
User story 3 calls for a shelter show page, which is a page for an individual shelter, containing that shelter's name and location information.
My Process:
Build feature test for shelter show page
- include shelter objects, an individual shelter's path, and expectations for it's show page (it should not include other shelters' information)
Include route
- in this case, the route is GET, and it links to the shelters controller, where it has access to the show action
Include show action in shelters controller
- the show action finds a specific shelter with a given id parameter
Create shelter show view
- as mentioned before, the show page does not include other shelters' information, therefore the view only renders the specified shelter for which a request is made by accessing the show action