### PR TITLE
Adopt Don't Shop U

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -18,6 +18,10 @@ class SheltersController < ApplicationController
     redirect_to "/shelters"
   end
 
+  def edit
+    @shelter = Shelter.find(params[:id])
+  end
+
   private
   def shelter_params
     params.permit(:name, :address, :city, :state, :zip)

--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -22,6 +22,14 @@ class SheltersController < ApplicationController
     @shelter = Shelter.find(params[:id])
   end
 
+  def update
+    @shelter = Shelter.find(params[:id])
+    @shelter.update(shelter_params)
+    @shelter.save
+
+    redirect_to "/shelters/#{@shelter.id}"
+  end
+
   private
   def shelter_params
     params.permit(:name, :address, :city, :state, :zip)

--- a/app/views/shelters/edit.html.erb
+++ b/app/views/shelters/edit.html.erb
@@ -1,20 +1,20 @@
-<h1>Edit this Shelter</h1>
+<h1>Edit: <%= @shelter.name %></h1>
 
 <%= form_tag "/shelters/#{@shelter.id}", method: :patch do %>
   <%= label_tag :name %>
-  <%= text_field_tag :name %></ br>
+  <%= text_field_tag :name %></br>
 
   <%= label_tag :address %>
-  <%= text_field_tag :address %></ br>
+  <%= text_field_tag :address %></br>
 
   <%= label_tag :city %>
-  <%= text_field_tag :city %></ br>
+  <%= text_field_tag :city %></br>
 
   <%= label_tag :state %>
-  <%= text_field_tag :state %></ br>
+  <%= text_field_tag :state %></br>
 
   <%= label_tag :zip %>
-  <%= text_field_tag :zip %></ br>
+  <%= text_field_tag :zip %></br>
 
   <%= submit_tag "Submit Update" %>
   <% end %>

--- a/app/views/shelters/edit.html.erb
+++ b/app/views/shelters/edit.html.erb
@@ -1,0 +1,20 @@
+<h1>Edit this Shelter</h1>
+
+<%= form_tag "/shelters/#{@shelter.id}", method: :patch do %>
+  <%= label_tag :name %>
+  <%= text_field_tag :name %></ br>
+
+  <%= label_tag :address %>
+  <%= text_field_tag :address %></ br>
+
+  <%= label_tag :city %>
+  <%= text_field_tag :city %></ br>
+
+  <%= label_tag :state %>
+  <%= text_field_tag :state %></ br>
+
+  <%= label_tag :zip %>
+  <%= text_field_tag :zip %></ br>
+
+  <%= submit_tag "Submit Update" %>
+  <% end %>

--- a/app/views/shelters/new.html.erb
+++ b/app/views/shelters/new.html.erb
@@ -1,3 +1,5 @@
+<h1>New Shelter Form</h1>
+
 <%= form_tag "/shelters" do %>
   <%= label_tag :name %>
   <%= text_field_tag :name %></br>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -2,4 +2,6 @@
 <p>Address: <%= @shelter.address %></p>
 <p>City: <%= @shelter.city %></p>
 <p>State: <%= @shelter.state %></p>
-<p>Zip: <%= @shelter.zip %></p>
+<p>Zip: <%= @shelter.zip %></p></br>
+
+<%= link_to "Update Shelter", "/shelters/#{@shelter.id}/edit" %>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -1,4 +1,5 @@
 <h1><%= @shelter.name %></h1>
+
 <p>Address: <%= @shelter.address %></p>
 <p>City: <%= @shelter.city %></p>
 <p>State: <%= @shelter.state %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   post '/shelters', to: 'shelters#create'
   get '/shelters/:id', to: 'shelters#show'
   get '/shelters/:id/edit', to: 'shelters#edit'
+  patch '/shelters/:id', to: 'shelters#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
+  # resources :shelters
   get '/shelters', to: 'shelters#index'
   get '/shelters/new', to: 'shelters#new'
   post '/shelters', to: 'shelters#create'
   get '/shelters/:id', to: 'shelters#show'
+  get '/shelters/:id/edit', to: 'shelters#edit'
 end

--- a/spec/features/shelters/shelter_show_spec.rb
+++ b/spec/features/shelters/shelter_show_spec.rb
@@ -15,9 +15,51 @@ RSpec.describe "Shelter Show Page" do
       expect(page).to have_content(shelter_1.zip)
       expect(page).to_not have_content(shelter_2.name)
     end
+
+    it "I can click on a link that lets me update that shelter using a form" do
+      shelter = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+
+      visit "/shelters/#{shelter.id}"
+
+      click_link "Update Shelter"
+
+      expect(current_path).to eq("/shelters/#{shelter.id}/edit")
+
+      fill_in "name", with: "Updated Shelter Name"
+      fill_in "address", with: "Updated Shelter Address"
+      fill_in "city", with: "Updated Shelter City"
+      fill_in "state", with: "Updated Shelter State"
+      fill_in "zip", with: "Updated Shelter Zip"
+
+      click_on "Submit Update"
+
+      expect(current_path).to eq("/shelters/#{shelter.id}")
+      expect(page).to have_content("Updated Shelter Name")
+      expect(page).to have_content("Updated Shelter Address")
+      expect(page).to have_content("Updated Shelter City")
+      expect(page).to have_content("Updated Shelter State")
+      expect(page).to have_content("Updated Shelter Zip")
+    end
   end
 end
 
+# User Story 5, Shelter Update
+#
+# As a visitor
+# When I visit a shelter show page
+# Then I see a link to update the shelter "Update Shelter"
+# When I click the link "Update Shelter"
+# Then I am taken to '/shelters/:id/edit' where I  see a form to edit the shelter's data including:
+# - name
+# - address
+# - city
+# - state
+# - zip
+# When I fill out the form with updated information
+# And I click the button to submit the form
+# Then a `PATCH` request is sent to '/shelters/:id',
+# the shelter's info is updated,
+# and I am redirected to the Shelter's Show page where I see the shelter's updated info
 
 
 # User Story 3, Shelter Show


### PR DESCRIPTION
Adopt Don't Shop User Story 5: Edit/Update Shelter Form (created a pull request with incomplete title and description section)

This user story requires a two step process such as when creating a new shelter. It provides access to a shelter edit form via a link in a shelter's show page. Once the form is filled out, a user can submit the shelter's updated information, and they will be redirected to the shelter's show page with new information. The name of the shelter is also updated within the shelters index page, if any changes are made to it.

My Process:
- add new test section to the shelter show spec file for updating a shelter (expect to see a link to update the shelter that links to an edit form with fields to fill out, and a submit button that redirects back to the show page)
- update shelter show page with link_to helper and edit path
- add edit shelter route, edit action with defined shelter instance, and create the edit view for the form (form_tag with patch method)
- add update route, and define update action (include shelter instance, referencing shelter params for the update method)