### PR TITLE
Adopt Don't Shop: One-to-Many Relationship Setup

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,0 +1,5 @@
+class Pet < ApplicationRecord
+  validates_presence_of :image, :name, :age, :sex, :shelter
+
+  belongs_to :shelter
+end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,3 +1,5 @@
 class Shelter < ApplicationRecord
+  validates_presence_of :name, :address, :city, :state, :zip
 
+  has_many :pets
 end

--- a/db/migrate/20200507172951_create_pets.rb
+++ b/db/migrate/20200507172951_create_pets.rb
@@ -1,0 +1,13 @@
+class CreatePets < ActiveRecord::Migration[5.1]
+  def change
+    create_table :pets do |t|
+      t.string :image
+      t.string :name
+      t.string :age
+      t.string :sex
+      t.string :shelter
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200507173259_add_shelters_to_pets.rb
+++ b/db/migrate/20200507173259_add_shelters_to_pets.rb
@@ -1,0 +1,5 @@
+class AddSheltersToPets < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :pets, :shelter, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200505034337) do
+ActiveRecord::Schema.define(version: 20200507173259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "pets", force: :cascade do |t|
+    t.string "image"
+    t.string "name"
+    t.string "age"
+    t.string "sex"
+    t.string "shelter"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "shelter_id"
+    t.index ["shelter_id"], name: "index_pets_on_shelter_id"
+  end
 
   create_table "shelters", force: :cascade do |t|
     t.string "name"
@@ -25,4 +37,5 @@ ActiveRecord::Schema.define(version: 20200505034337) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "pets", "shelters"
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Pet do
+  describe "validations" do
+    it {should validate_presence_of :name}
+  end
+
+  describe "relationships" do
+    it {should belong_to :shelter}
+  end
+end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Shelter do
+  describe "validations" do
+    it {should validate_presence_of :name}
+  end
+
+  describe "relationships" do
+    it {should have_many :pets}
+  end
+end


### PR DESCRIPTION
Before continuing to develop functionality the app, I want to create a one-to-many relationship between a shelter and its pets. This is based on the first user story for Pets. As with everything, I start with checking out a new branch.
My process:
- build a model spec file for shelter with validations and relationships (validations are the initial attributes of a table, and can change with future migrations)
- create a shelter model that validates attributes and includes its relationships (relationships refer to the connection between the model table and other tables; in this case, a shelter has many pets)
- running rspec guides you to create missing Per model spec and model with its own validations and relationships (in this case, a pet belongs to a shelter)
- create migrations for each model table with attributes and their datatypes (add timestamps before running the migration; migrations make a change to the structure of your database)
- create additional migration to add foreign key to the pets table that references a shelter's id (completes the one-to-many relationship)