### PR TITLE
Adopt Don't Shop US 7: Pets Index Page

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,0 +1,5 @@
+class PetsController < ApplicationController
+  def index
+    @pets = Pet.all
+  end
+end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,5 +1,5 @@
 class Pet < ApplicationRecord
-  validates_presence_of :image, :name, :age, :sex, :shelter
+  validates_presence_of :name, :age, :sex, :image
 
   belongs_to :shelter
 end

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Pets Index</h1>
+
+<% @pets.each do |pet| %>
+  <h3>Pet: <%= pet.name %></h3>
+  <img src="<%= pet.image %>" width="150" height="120">
+  <ul>
+    <li>Approximate Age: <%= pet.age %></li>
+    <li>Sex: <%= pet.sex %></li>
+    <li>Located at: <%= pet.shelter.name %></li>
+  </ul>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   resources :shelters
+  get '/pets', to: 'pets#index'
 end

--- a/db/migrate/20200507185808_remove_shelter_from_pets.rb
+++ b/db/migrate/20200507185808_remove_shelter_from_pets.rb
@@ -1,0 +1,5 @@
+class RemoveShelterFromPets < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pets, :shelter, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200507173259) do
+ActiveRecord::Schema.define(version: 20200507185808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20200507173259) do
     t.string "name"
     t.string "age"
     t.string "sex"
-    t.string "shelter"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "shelter_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,5 +5,13 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+Shelter.destroy_all
+Pet.destroy_all
+
 shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
 shelter_2 = Shelter.create(name: "Foothils Animal Shelter", address: "580 McIntyre St", city: "Golden", state: "CO", zip: "80401")
+
+bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
+simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+starla = shelter_2.pets.create(name: "Starla", age: "18", sex: "F", image: "https://images.pexels.com/photos/1605481/pexels-photo-1605481.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")
+jasper = shelter_2.pets.create(name: "Jasper", age: "11", sex: "M", image: "https://images.pexels.com/photos/1543793/pexels-photo-1543793.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")

--- a/spec/features/pets/pets_index_spec.rb
+++ b/spec/features/pets/pets_index_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe "Pets Index Page" do
+  describe "as a visitor when I visit the pets index spec" do
+    it "I can see the name of each shelter in the system" do
+      shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+      shelter_2 = Shelter.create(name: "Foothils Animal Shelter", address: "580 McIntyre St", city: "Golden", state: "CO", zip: "80401")
+
+      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", image: "insert image here")
+      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", image: "insert image here")
+      starla = shelter_2.pets.create(name: "Starla", age: "18", sex: "F", image: "insert image here")
+      jasper = shelter_2.pets.create(name: "Jasper", age: "11", sex: "M", image: "insert image here")
+
+      visit "/pets"
+
+      expect(page).to have_content(bishi.name)
+      expect(page).to have_content(simba.age)
+      expect(page).to_not have_content(starla.sex)
+      expect(page).to_not have_content(shelter.name)
+      expect(page).to_not have_content(jasper.image)
+    end
+  end
+end
+
+# User Story 7, Pet Index
+#
+# As a visitor
+# When I visit '/pets'
+# Then I see each Pet in the system including the Pet's:
+# - image
+# - name
+# - approximate age
+# - sex
+# - name of the shelter where the pet is currently located

--- a/spec/features/pets/pets_index_spec.rb
+++ b/spec/features/pets/pets_index_spec.rb
@@ -6,21 +6,22 @@ RSpec.describe "Pets Index Page" do
       shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
       shelter_2 = Shelter.create(name: "Foothils Animal Shelter", address: "580 McIntyre St", city: "Golden", state: "CO", zip: "80401")
 
-      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", image: "insert image here")
-      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", image: "insert image here")
-      starla = shelter_2.pets.create(name: "Starla", age: "18", sex: "F", image: "insert image here")
-      jasper = shelter_2.pets.create(name: "Jasper", age: "11", sex: "M", image: "insert image here")
+      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
+      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+      starla = shelter_2.pets.create(name: "Starla", age: "18", sex: "F", image: "https://images.pexels.com/photos/1605481/pexels-photo-1605481.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")
+      jasper = shelter_2.pets.create(name: "Jasper", age: "11", sex: "M", image: "https://images.pexels.com/photos/1543793/pexels-photo-1543793.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")
 
       visit "/pets"
 
-      expect(page).to have_content(bishi.name)
-      expect(page).to have_content(simba.age)
-      expect(page).to_not have_content(starla.sex)
-      expect(page).to_not have_content(shelter.name)
-      expect(page).to_not have_content(jasper.image)
+      expect(page).to have_content("Pet: #{bishi.name}")
+      expect(page).to have_content("Approximate Age: #{simba.age}")
+      expect(page).to have_content("Sex: #{starla.sex}")
+      expect(page).to have_css("img[src*='#{jasper.image}']")
+      expect(page).to have_content("Located at: #{shelter_1.name}")
     end
   end
 end
+
 
 # User Story 7, Pet Index
 #


### PR DESCRIPTION
In order to build a pets index page, I followed these steps:
- build features test for the pets index (the one to many relationship between a shelter and pets should be considered)
- create a get route for pets index
- define index action within a pets controller
- setup the pets index view (utilized img src tag)
During the process, I ran into an issue involving my migrations during the relationship setup. I mistakenly added an additional column for shelter within the pets table, and therefore, had to remove said column so the foreign key connection would work properly.
My process also included updating the feature test and seed file, as I learned more about image implementation, and acquired image urls to use in the app by using the inspect function on images.