### PR TITLE
Adopt Don't Shop US 9: create Pets Show Page

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,4 +2,8 @@ class PetsController < ApplicationController
   def index
     @pets = Pet.all
   end
+
+  def show
+    @pet = Pet.find(params[:id])
+  end
 end

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -1,0 +1,8 @@
+<img src="<%= @pet.image %>" width="150" height="120">
+
+<h1><%= @pet.name %></h1>
+
+<p>Approximate Age: <%= @pet.age %></p>
+<p>Sex: <%= @pet.sex %></p>
+<p>Description: <%= @pet.description %></p>
+<p>Adoption Status: <%= @pet.adoption_status %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
   resources :shelters
   get '/pets', to: 'pets#index'
+  get '/pets/:id', to: 'pets#show'
 end

--- a/db/migrate/20200509225603_add_description_to_pets.rb
+++ b/db/migrate/20200509225603_add_description_to_pets.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToPets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pets, :description, :string
+  end
+end

--- a/db/migrate/20200509225641_add_adoption_status_to_pets.rb
+++ b/db/migrate/20200509225641_add_adoption_status_to_pets.rb
@@ -1,0 +1,5 @@
+class AddAdoptionStatusToPets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pets, :adoption_status, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200507185808) do
+ActiveRecord::Schema.define(version: 20200509225641) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 20200507185808) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "shelter_id"
+    t.string "description"
+    t.string "adoption_status"
     t.index ["shelter_id"], name: "index_pets_on_shelter_id"
   end
 

--- a/spec/features/pets/pet_show_spec.rb
+++ b/spec/features/pets/pet_show_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe "Pet Show Page" do
+  describe "as a visitor when I visit a pet's show page" do
+    it "I can see that pet's information, inluding adoption status" do
+      shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+
+      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
+      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+
+      visit "/pets/#{bishi.id}"
+
+      expect(page).to have_content(bishi.name)
+      expect(page).to have_content("Description: #{bishi.description}")
+      expect(page).to have_content("Adoption Status: #{bishi.adoption_status}")
+      expect(page).to_not have_content(simba.name)
+    end
+  end
+end
+
+# User Story 9, Pet Show
+#
+# As a visitor
+# When I visit '/pets/:id'
+# Then I see the pet with that id including the pet's:
+# - image
+# - name
+# - description
+# - approximate age
+# - sex
+# - adoptable/pending adoption status


### PR DESCRIPTION
I took the following steps to create a pet's show page:
Process:
- write feature test for pet's show page (expect page to include a pet's information such as name, description, and adoption status)
- create get route to show action within pets controller, defining show action to provide individual pet object information
- build pet's show page view
- create migrations for adding description and adoption status to pet objects
