### PR TITLE
Adopt Don't Shop US 11: Edit Form/Update Pet

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -6,4 +6,8 @@ class PetsController < ApplicationController
   def show
     @pet = Pet.find(params[:id])
   end
+
+  def edit
+    @pet = Pet.find(params[:id])
+  end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -10,4 +10,17 @@ class PetsController < ApplicationController
   def edit
     @pet = Pet.find(params[:id])
   end
+
+  def update
+    @pet = Pet.find(params[:id])
+    @pet.update(pet_params)
+    @pet.save
+
+    redirect_to "/pets/#{@pet.id}"
+  end
+
+  private
+  def pet_params
+    params.permit(:image, :name, :age, :sex, :description)
+  end
 end

--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -1,0 +1,20 @@
+<h1>Edit: <%= @pet.name %></h1>
+
+<%= form_tag "/pets/#{@pet.id}", method: :patch do %>
+  <%= label_tag :image %>
+  <%= text_field_tag :image %></br>
+
+  <%= label_tag :name %>
+  <%= text_field_tag :name %></br>
+
+  <%= label_tag :age %>
+  <%= text_field_tag :age %></br>
+
+  <%= label_tag :sex %>
+  <%= text_field_tag :sex %></br>
+
+  <%= label_tag :description %>
+  <%= text_field_tag :description %></br>
+
+  <%= submit_tag "Submit Update" %>
+<% end %>

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -6,3 +6,5 @@
 <p>Sex: <%= @pet.sex %></p>
 <p>Description: <%= @pet.description %></p>
 <p>Adoption Status: <%= @pet.adoption_status %></p>
+
+<%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   get '/pets', to: 'pets#index'
   get '/pets/:id', to: 'pets#show'
   get '/pets/:id/edit', to: 'pets#edit'
+  patch '/pets/:id', to: 'pets#update'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   resources :shelters
   get '/pets', to: 'pets#index'
   get '/pets/:id', to: 'pets#show'
+  get '/pets/:id/edit', to: 'pets#edit'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,7 @@ Pet.destroy_all
 shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
 shelter_2 = Shelter.create(name: "Foothils Animal Shelter", address: "580 McIntyre St", city: "Golden", state: "CO", zip: "80401")
 
-bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
-simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
-starla = shelter_2.pets.create(name: "Starla", age: "18", sex: "F", image: "https://images.pexels.com/photos/1605481/pexels-photo-1605481.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")
-jasper = shelter_2.pets.create(name: "Jasper", age: "11", sex: "M", image: "https://images.pexels.com/photos/1543793/pexels-photo-1543793.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260")
+bishi = shelter_1.pets.create(image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932", name: "Bishi", age: "10", sex: "M")
+simba = shelter_1.pets.create(image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260", name: "Simba", age: "2", sex: "M")
+starla = shelter_2.pets.create(image: "https://images.pexels.com/photos/1605481/pexels-photo-1605481.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260", name: "Starla", age: "18", sex: "F")
+jasper = shelter_2.pets.create(image: "https://images.pexels.com/photos/1543793/pexels-photo-1543793.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260", name: "Jasper", age: "11", sex: "M")

--- a/spec/features/pets/pet_show_spec.rb
+++ b/spec/features/pets/pet_show_spec.rb
@@ -15,8 +15,53 @@ RSpec.describe "Pet Show Page" do
       expect(page).to have_content("Adoption Status: #{bishi.adoption_status}")
       expect(page).to_not have_content(simba.name)
     end
+
+    it "I can click on a link that lets me update that pet using a form" do
+      shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+
+      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
+      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+
+      visit "/pets/#{bishi.id}"
+      click_link "Update Pet"
+
+      expect(current_path).to eq("/pets/#{bishi.id}/edit")
+
+      fill_in "image", with: "Updated Pet Image"
+      fill_in "name", with: "Updated Pet name"
+      fill_in "age", with: "Updated Pet Age"
+      fill_in "sex", with: "Updated Pet Sex"
+      fill_in "description", with: "Updated Pet Description"
+
+      click_on "Submit Update"
+
+      expect(current_path).to eq("/pets/#{bishi.id}")
+      expect(page).to have_content("Updated Pet Image")
+      expect(page).to have_content("Updated Pet name")
+      expect(page).to have_content("Updated Pet Age")
+      expect(page).to have_content("Updated Pet Sex")
+      expect(page).to have_content("Updated Pet Description")
+    end
   end
 end
+
+# User Story 11, Pet Update
+#
+# As a visitor
+# When I visit a Pet Show page
+# Then I see a link to update that Pet "Update Pet"
+# When I click the link
+# I am taken to '/pets/:id/edit' where I see a form to edit the pet's data including:
+# - image
+# - name
+# - description
+# - approximate age
+# - sex
+# When I click the button to submit the form "Update Pet"
+# Then a `PATCH` request is sent to '/pets/:id',
+# the pet's data is updated,
+# and I am redirected to the Pet Show page where I see the Pet's updated information
+
 
 # User Story 9, Pet Show
 #

--- a/spec/features/pets/pet_show_spec.rb
+++ b/spec/features/pets/pet_show_spec.rb
@@ -17,18 +17,18 @@ RSpec.describe "Pet Show Page" do
     end
 
     it "I can click on a link that lets me update that pet using a form" do
-      shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+      shelter = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
 
-      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
-      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+      bishi = shelter.pets.create(image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932", name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable")
 
       visit "/pets/#{bishi.id}"
+
       click_link "Update Pet"
 
       expect(current_path).to eq("/pets/#{bishi.id}/edit")
 
-      fill_in "image", with: "Updated Pet Image"
-      fill_in "name", with: "Updated Pet name"
+      fill_in "image", with: "https://images.pexels.com/photos/881142/pexels-photo-881142.jpeg?auto=compress&cs=tinysrgb&dpr=3&h=750&w=1260"
+      fill_in "name", with: "Updated Pet Name"
       fill_in "age", with: "Updated Pet Age"
       fill_in "sex", with: "Updated Pet Sex"
       fill_in "description", with: "Updated Pet Description"
@@ -36,8 +36,7 @@ RSpec.describe "Pet Show Page" do
       click_on "Submit Update"
 
       expect(current_path).to eq("/pets/#{bishi.id}")
-      expect(page).to have_content("Updated Pet Image")
-      expect(page).to have_content("Updated Pet name")
+      expect(page).to have_content("Updated Pet Name")
       expect(page).to have_content("Updated Pet Age")
       expect(page).to have_content("Updated Pet Sex")
       expect(page).to have_content("Updated Pet Description")


### PR DESCRIPTION
Updating a Pet requires an edit page. The following steps helped me build this functionality:
1. add feature test for pet edit form page to pet show spec file (include: shelter, pet, expected links and buttons with paths, form fill in information, and expected results)
2. update pet show view with link "Update Pet" with path to the edit form
3. create get route for edit action, and define edit action in pets controller (it should be able to find a specific pet)
4. build pet edit form view (include full form tag with path and patch method)
5. create the patch route for update action
6. define update action and pet params within the pet controller to be able to access the given parameters (update methods: .find, .update(passed in parameters), .save, pet params: .permit), then redirect to show page with updated information
Note: I had a bit of trouble accessing some information, and through investigative work, I leaned that my objects attributes had changed, so I updated the spec file and seeds for the changes to be recognized in the database.