### PR TITLE
Adopt Don't Shop US 12: Delete Pet Functionality

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -19,6 +19,12 @@ class PetsController < ApplicationController
     redirect_to "/pets/#{@pet.id}"
   end
 
+  def destroy
+    Pet.destroy(params[:id])
+
+    redirect_to "/pets"
+  end
+
   private
   def pet_params
     params.permit(:image, :name, :age, :sex, :description)

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -7,4 +7,5 @@
 <p>Description: <%= @pet.description %></p>
 <p>Adoption Status: <%= @pet.adoption_status %></p>
 
-<%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %>
+<%= link_to "Update Pet", "/pets/#{@pet.id}/edit" %></br>
+<%= link_to "Delete Pet", "/pets/#{@pet.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get '/pets/:id', to: 'pets#show'
   get '/pets/:id/edit', to: 'pets#edit'
   patch '/pets/:id', to: 'pets#update'
+  delete '/pets/:id', to: 'pets#destroy'
 end

--- a/spec/features/pets/pet_show_spec.rb
+++ b/spec/features/pets/pet_show_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Pet Show Page" do
     it "I can see that pet's information, inluding adoption status" do
       shelter_1 = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
 
-      bishi = shelter_1.pets.create(name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable", image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932")
-      simba = shelter_1.pets.create(name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending", image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260")
+      bishi = shelter_1.pets.create(image: "https://ih.constantcontact.com/fs159/1104169690227/img/112.jpg?a=1118551010932", name: "Bishi", age: "10", sex: "M", description: "Reserved, but with a mischivous flare about him, he always let's you know what is on his mind.", adoption_status: "Adoptable")
+      simba = shelter_1.pets.create(image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260", name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending")
 
       visit "/pets/#{bishi.id}"
 
@@ -41,8 +41,32 @@ RSpec.describe "Pet Show Page" do
       expect(page).to have_content("Updated Pet Sex")
       expect(page).to have_content("Updated Pet Description")
     end
+
+    it "I can click a link that deletes that pet, taking me to the pets index page" do
+      shelter = Shelter.create(name: "Cat Care Society", address: "5787 W 6th Ave", city: "Lakewood", state: "CO", zip: "80214")
+
+      simba = shelter.pets.create(image: "https://images.pexels.com/photos/736532/pexels-photo-736532.jpeg?auto=compress&amp;cs=tinysrgb&amp;dpr=3&amp;h=750&amp;w=1260", name: "Simba", age: "2", sex: "M", description: "His love of life and curiosity are so contagious, you'll find yourself wanting to explore the world by his side.", adoption_status: "Pending")
+
+      visit "/pets/#{simba.id}"
+
+      click_link "Delete Pet"
+
+      expect(current_path).to eq("/pets")
+      expect(page).to_not have_content(simba.name)
+    end
   end
 end
+
+# User Story 12, Pet Delete
+#
+# As a visitor
+# When I visit a pet show page
+# Then I see a link to delete the pet "Delete Pet"
+# When I click the link
+# Then a 'DELETE' request is sent to '/pets/:id',
+# the pet is deleted,
+# and I am redirected to the pet index page where I no longer see this pet
+
 
 # User Story 11, Pet Update
 #


### PR DESCRIPTION
Following these steps, I built the delete/destroy functionality for a pet show page:
1. add delete pet show page test (include: shelter, pet, expectation of a link and its path, and expecting results)
2. edit pet show page view to include a link to delete pet (the delete link should point to a path and define a delete method)
3. create delete route to destroy action, and define destroy action (within pets controller the destroy action deletes a pet from the database with the matching id fo which a delete request is made,  and redirects back to the pets index page where the pet no longer exists)